### PR TITLE
Cleanup Xcode warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c 
-osx_image: xcode7.1
+osx_image: xcode7.3
 before_install:
 - brew update
 - brew install mosquitto

--- a/SwiftMQTT/SwiftMQTT/MQTTSession.swift
+++ b/SwiftMQTT/SwiftMQTT/MQTTSession.swift
@@ -87,7 +87,7 @@ public class MQTTSession: MQTTSessionStreamDelegate {
         stream.delegate = self
         stream.createStreamConnection()
         
-        keepAliveTimer = NSTimer(timeInterval: Double(self.keepAlive), target: self, selector: Selector("keepAliveTimerFired"), userInfo: nil, repeats: true)
+        keepAliveTimer = NSTimer(timeInterval: Double(self.keepAlive), target: self, selector: #selector(MQTTSession.keepAliveTimerFired), userInfo: nil, repeats: true)
         NSRunLoop.mainRunLoop().addTimer(keepAliveTimer, forMode: NSDefaultRunLoopMode)
         
         //Create Connect Packet
@@ -175,8 +175,8 @@ public class MQTTSession: MQTTSessionStreamDelegate {
         struct MessageIDHolder {
             static var messageID = UInt16(0)
         }
-        MessageIDHolder.messageID++
-        return MessageIDHolder.messageID;
+        MessageIDHolder.messageID += 1
+        return MessageIDHolder.messageID
     }
 
     //MARK:- MQTTSessionStreamDelegates


### PR DESCRIPTION
This pull request cleans up two warnings in Xcode related to  constructing a `Selector` explicitly rather than the newer/safer `#selector` method and the deprecation of the C-style `++` operator.